### PR TITLE
Rule about the interaction between bind and return in dk_monads.dk

### DIFF
--- a/dk_monads.dk
+++ b/dk_monads.dk
@@ -48,7 +48,8 @@ def comp :
     bind M B C (f x) g.
 (; monadic laws ;)
 
-[A,f,a] bind _ A _ (return _ A a) f --> f a.
+[A,f,a,M]
+        bind M A _ (return M A a) f --> f a.
 
 [M,A,m] bind M A A m (return M A) --> m.
 


### PR DESCRIPTION
made non-linear to deal with the non-injectivecty of cc.eT