### PR TITLE
More configurable Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ DKS = $(wildcard *.dk)
 DKOS = $(DKS:.dk=.dko)
 DKDEPENDS = $(DKS:.dk=.dk.depend)
 
-DKDEP = dkdep
-DKCHECK = dkcheck
+DKDEP ?= dkdep
+DKCHECK ?= dkcheck
 DKCHECK_OPTIONS =
 CSIHO_PATH =
 ifeq ($(CSIHO_PATH),)


### PR DESCRIPTION
Makefile should be configurable through global variables such as DKCHECK and DKDEP.
I'd like to be able to do
```
export DKCHECK=/path/to/my/custom/dkcheck.native
make -C /path/to/dklib
```